### PR TITLE
fix: cache the precomputed ridden-roads overlay client-side

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ import { RwgpsSuccessDialog } from '@/components/RwgpsSuccessDialog';
 import { RwgpsHeaderButton } from '@/components/RwgpsHeaderButton';
 import { HowToDialog } from '@/components/HowToDialog';
 import { ExportTipsDialog } from '@/components/ExportTipsDialog';
-import { getCachedRoads, setCachedRoads, clearCachedRoads } from '@/lib/stravaCache';
+import { getCachedRoads, setCachedRoads, clearCachedRoads, getCachedPrecomputedRoads, setCachedPrecomputedRoads, clearCachedPrecomputedRoads } from '@/lib/stravaCache';
 import { getAffectedSegmentIndices, applyMovedPoint, insertWaypointAtSegment, removeWaypoint, Waypoint } from '@/lib/pointMove';
 import { RouteSnapshot, undo, redo, isFirstPointAfterArea, shouldAddComputedEndpoint } from '@/lib/routeHistory';
 
@@ -302,13 +302,20 @@ export default function Home() {
         });
     }, [stravaCredentials, stravaRefreshKey]);
 
-    // Fetch the server-precomputed, deduped ridden-road overlay once. It's
+    // Fetch the server-precomputed, deduped ridden-road overlay. It's
     // viewport-independent, so the map draws it instantly with no per-pan wait.
+    // This payload can run several MB for a rider with a lot of history, and
+    // the server itself only refreshes it on its own ~24h timer — so it's
+    // cached client-side (IndexedDB) the same way /api/strava/activities
+    // already is, instead of re-fetching the full payload on every page load.
     useEffect(() => {
         if (!stravaCredentials?.refreshToken) { setPrecomputedRidden(null); return; }
         let cancelled = false;
         let timer: ReturnType<typeof setTimeout> | null = null;
-        const load = async () => {
+        const credentialsKey = JSON.stringify(stravaCredentials);
+        const skipCache = stravaRefreshKey > 0;
+
+        const fetchFresh = async () => {
             try {
                 const res = await fetch('/api/ridden-roads', {
                     method: 'POST',
@@ -317,11 +324,26 @@ export default function Home() {
                 });
                 const data = await res.json();
                 if (cancelled || data.error) return;
-                if (Array.isArray(data.roads) && data.roads.length > 0) setPrecomputedRidden(data.roads);
-                if ((data.computing || data.refreshing) && !cancelled) timer = setTimeout(load, 8000);
+                if (Array.isArray(data.roads) && data.roads.length > 0) {
+                    setPrecomputedRidden(data.roads);
+                    setCachedPrecomputedRoads(data.roads, data.refreshedAt ?? null, credentialsKey);
+                }
+                if ((data.computing || data.refreshing) && !cancelled) timer = setTimeout(fetchFresh, 8000);
             } catch { /* leave client fallback in place */ }
         };
-        load();
+
+        if (skipCache) {
+            fetchFresh();
+        } else {
+            getCachedPrecomputedRoads(credentialsKey).then(cachedRoads => {
+                if (cancelled) return;
+                if (cachedRoads) {
+                    setPrecomputedRidden(cachedRoads);
+                } else {
+                    fetchFresh();
+                }
+            });
+        }
         return () => { cancelled = true; if (timer) clearTimeout(timer); };
     }, [stravaCredentials, stravaRefreshKey]);
 
@@ -1168,6 +1190,7 @@ ${route.map(pt => `      <trkpt lat="${pt[1]}" lon="${pt[0]}">${pt[2] !== undefi
                         onClick={() => setShowStravaSettings(true)}
                         onRefresh={() => {
                             clearCachedRoads();
+                            clearCachedPrecomputedRoads();
                             setStravaRefreshKey(k => k + 1);
                         }}
                     />
@@ -1488,6 +1511,7 @@ ${route.map(pt => `      <trkpt lat="${pt[1]}" lon="${pt[0]}">${pt[2] !== undefi
                         onClick={() => setShowStravaSettings(true)}
                         onRefresh={() => {
                             clearCachedRoads();
+                            clearCachedPrecomputedRoads();
                             setStravaRefreshKey(k => k + 1);
                         }}
                     />

--- a/lib/stravaCache.ts
+++ b/lib/stravaCache.ts
@@ -2,6 +2,15 @@ const DB_NAME = 'streetsweep';
 const STORE_NAME = 'strava_cache';
 const CACHE_KEY = 'ridden_roads';
 const TTL_MS = 24 * 60 * 60 * 1000;
+// Separate cache entry for the server-precomputed, deduped ridden-road
+// overlay (/api/ridden-roads) — this payload can run several MB for a rider
+// with a lot of history, and the server itself only refreshes it on its own
+// ~24h timer, so re-fetching it on every page load was pure wasted transfer
+// (this endpoint had no client-side caching at all before). Its own key
+// avoids colliding with the raw-activity cache above, which has a different
+// shape and its own version/TTL lifecycle.
+const PRECOMPUTED_CACHE_KEY = 'precomputed_ridden_roads';
+const PRECOMPUTED_TTL_MS = 12 * 60 * 60 * 1000;
 // Bump when the shape/semantics of cached rides change so stale entries are
 // discarded. v2: rides are cycling-only (walks/hikes/runs excluded upstream).
 // v3: virtual/indoor and stationary trainer rides also excluded.
@@ -78,6 +87,61 @@ export async function clearCachedRoads(): Promise<void> {
         await new Promise<void>((resolve, reject) => {
             const tx = db.transaction(STORE_NAME, 'readwrite');
             const req = tx.objectStore(STORE_NAME).delete(CACHE_KEY);
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+        });
+    } catch {
+        // Silently ignore
+    }
+}
+
+interface PrecomputedCacheEntry {
+    roads: [number, number][][];
+    refreshedAt: string | null;
+    cachedAt: number;
+    credentialsKey: string;
+}
+
+export async function getCachedPrecomputedRoads(credentialsKey: string): Promise<[number, number][][] | null> {
+    try {
+        const db = await openDB();
+        const entry = await new Promise<PrecomputedCacheEntry | undefined>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly');
+            const req = tx.objectStore(STORE_NAME).get(PRECOMPUTED_CACHE_KEY);
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+        });
+        if (!entry || entry.credentialsKey !== credentialsKey) return null;
+        if (Date.now() - entry.cachedAt > PRECOMPUTED_TTL_MS) return null;
+        return entry.roads;
+    } catch {
+        return null;
+    }
+}
+
+export async function setCachedPrecomputedRoads(roads: [number, number][][], refreshedAt: string | null, credentialsKey: string): Promise<void> {
+    try {
+        const db = await openDB();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const req = tx.objectStore(STORE_NAME).put(
+                { roads, refreshedAt, cachedAt: Date.now(), credentialsKey } satisfies PrecomputedCacheEntry,
+                PRECOMPUTED_CACHE_KEY
+            );
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+        });
+    } catch {
+        // Caching is best-effort — silently ignore failures
+    }
+}
+
+export async function clearCachedPrecomputedRoads(): Promise<void> {
+    try {
+        const db = await openDB();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const req = tx.objectStore(STORE_NAME).delete(PRECOMPUTED_CACHE_KEY);
             req.onsuccess = () => resolve();
             req.onerror = () => reject(req.error);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "street-sweep",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "street-sweep",
-      "version": "0.6.43",
+      "version": "0.6.44",
       "hasInstallScript": true,
       "dependencies": {
         "@garmin/fitsdk": "^21.202.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "street-sweep",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3888",


### PR DESCRIPTION
## Summary
- `/api/ridden-roads` had no client-side caching, so every page load re-fetched the full server-precomputed ridden-road overlay (measured 5.66MB for one real account) even though the server only refreshes it on its own ~24h timer — the main suspected driver of hitting the Vercel Fast Origin Transfer free-tier cap.
- Adds a 12h IndexedDB cache for this payload, matching the existing pattern already used for `/api/strava/activities`.
- Manual "Sync" still bypasses the cache and clears both caches.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (288 passing)
- [ ] Confirm in production that repeat page loads no longer re-fetch the full ridden-roads payload