### PR TITLE
feat: cycling vs running activity mode

### DIFF
--- a/app/api/ridden-roads/route.ts
+++ b/app/api/ridden-roads/route.ts
@@ -16,6 +16,12 @@ const TILE = 0.02; // ~2.2km tiles to gather OSM roads over the riding footprint
 const MAX_TILES = Number(process.env.RIDDEN_MAX_TILES ?? 5000);
 
 interface Creds { clientId?: string; clientSecret?: string; refreshToken?: string }
+type ActivityMode = 'cycling' | 'running';
+
+// Cycling stays on the bare athleteId key so existing cached rows keep
+// matching (no DB migration needed); running gets a distinct suffixed key so
+// switching modes never mixes the two activity sets in the same cache row.
+const cacheKey = (athleteId: string, mode: ActivityMode) => mode === 'running' ? `${athleteId}__running` : athleteId;
 
 const REFRESHING = new Set<string>();
 
@@ -55,48 +61,51 @@ async function compute(riddenRoads: [number, number][][]): Promise<[number, numb
     return dedupeRiddenRoads(riddenRoads, roads);
 }
 
-async function refreshInBackground(athleteId: string, creds: Creds) {
-    if (REFRESHING.has(athleteId)) return;
-    REFRESHING.add(athleteId);
+async function refreshInBackground(athleteId: string, creds: Creds, mode: ActivityMode) {
+    const key = cacheKey(athleteId, mode);
+    if (REFRESHING.has(key)) return;
+    REFRESHING.add(key);
     try {
-        console.log(`${ts()} RiddenRoads: refresh starting for ${athleteId}`);
-        const { riddenRoads } = await fetchCyclingRiddenRoads(creds);
+        console.log(`${ts()} RiddenRoads: refresh starting for ${key}`);
+        const { riddenRoads } = await fetchCyclingRiddenRoads(creds, mode);
         const roads = await compute(riddenRoads);
         await prisma.riddenRoadsCache.upsert({
-            where: { athleteId },
-            create: { athleteId, roads: roads as any, version: RIDDEN_VERSION, refreshedAt: new Date() },
+            where: { athleteId: key },
+            create: { athleteId: key, roads: roads as any, version: RIDDEN_VERSION, refreshedAt: new Date() },
             update: { roads: roads as any, version: RIDDEN_VERSION, refreshedAt: new Date() },
         });
-        console.log(`${ts()} RiddenRoads: cached ${roads.length} segments for ${athleteId}`);
+        console.log(`${ts()} RiddenRoads: cached ${roads.length} segments for ${key}`);
     } catch (e: any) {
-        console.warn(`${ts()} RiddenRoads refresh failed for ${athleteId}: ${e.message}`);
+        console.warn(`${ts()} RiddenRoads refresh failed for ${key}: ${e.message}`);
     } finally {
-        REFRESHING.delete(athleteId);
+        REFRESHING.delete(key);
     }
 }
 
 export async function POST(request: Request) {
     try {
-        const { stravaCredentials } = await request.json() as { stravaCredentials?: Creds };
+        const { stravaCredentials, activityMode } = await request.json() as { stravaCredentials?: Creds; activityMode?: string };
         if (!stravaCredentials?.refreshToken) {
             return NextResponse.json({ error: 'stravaCredentials.refreshToken required' }, { status: 400 });
         }
+        const mode: ActivityMode = activityMode === 'running' ? 'running' : 'cycling';
         const athleteId = await resolveAthleteId(stravaCredentials);
-        const cached = await prisma.riddenRoadsCache.findUnique({ where: { athleteId } });
+        const key = cacheKey(athleteId, mode);
+        const cached = await prisma.riddenRoadsCache.findUnique({ where: { athleteId: key } });
 
         if (cached) {
             const stale = Date.now() - cached.refreshedAt.getTime() > FRESH_TTL_MS;
             const outdated = (cached.version ?? 1) < RIDDEN_VERSION;
-            if (stale || outdated) refreshInBackground(athleteId, stravaCredentials);
+            if (stale || outdated) refreshInBackground(athleteId, stravaCredentials, mode);
             return NextResponse.json({
                 roads: cached.roads,
                 refreshedAt: cached.refreshedAt.toISOString(),
-                refreshing: REFRESHING.has(athleteId),
+                refreshing: REFRESHING.has(key),
                 computing: false,
             });
         }
 
-        refreshInBackground(athleteId, stravaCredentials);
+        refreshInBackground(athleteId, stravaCredentials, mode);
         return NextResponse.json({ roads: [], refreshedAt: null, refreshing: true, computing: true });
     } catch (e: any) {
         console.error('RiddenRoads route error:', e);

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -71,6 +71,13 @@ interface StravaCredentials {
     refreshToken?: string;
 }
 
+type ActivityMode = 'cycling' | 'running';
+
+// Cycling stays on the bare athleteId key so existing cached rows keep
+// matching (no DB migration needed); running gets a distinct suffixed key so
+// switching modes never mixes the two activity sets in the same cache row.
+const cacheKey = (athleteId: string, mode: ActivityMode) => mode === 'running' ? `${athleteId}__running` : athleteId;
+
 function networkPolylinesFromOSM(data: { elements: any[] }): [number, number][][] {
     const nodeMap = new Map<number, { lat: number; lon: number }>();
     for (const el of data.elements) {
@@ -299,34 +306,37 @@ async function persistStats(athleteId: string, stats: StatsPayload): Promise<voi
     }), 'persist');
 }
 
-async function refreshInBackground(athleteId: string, creds: StravaCredentials) {
-    if (REFRESHING.has(athleteId)) return;
-    REFRESHING.add(athleteId);
+async function refreshInBackground(athleteId: string, creds: StravaCredentials, mode: ActivityMode) {
+    const key = cacheKey(athleteId, mode);
+    if (REFRESHING.has(key)) return;
+    REFRESHING.add(key);
     try {
-        console.log(`${ts()} Stats: background refresh starting for athlete ${athleteId}`);
+        console.log(`${ts()} Stats: background refresh starting for ${key}`);
         // Fetch the ride set server-side so the client never has to ship it in
         // the request body (which a reverse proxy would reject as too large).
-        const { riddenRoads, activityElevations, activityDistances, activityStartDates, totalCyclingActivities, totalCyclingElevationGainMeters } = await fetchCyclingRiddenRoads(creds);
+        const { riddenRoads, activityElevations, activityDistances, activityStartDates, totalCyclingActivities, totalCyclingElevationGainMeters } = await fetchCyclingRiddenRoads(creds, mode);
         const fresh = await computeStats(riddenRoads, activityElevations, activityDistances, activityStartDates, totalCyclingActivities, totalCyclingElevationGainMeters);
-        await persistStats(athleteId, fresh);
-        console.log(`${ts()} Stats: background refresh complete for athlete ${athleteId}`);
+        await persistStats(key, fresh);
+        console.log(`${ts()} Stats: background refresh complete for ${key}`);
     } catch (e: any) {
-        console.warn(`${ts()} Stats: background refresh failed for ${athleteId}:`, e?.message || e);
+        console.warn(`${ts()} Stats: background refresh failed for ${key}:`, e?.message || e);
     } finally {
-        REFRESHING.delete(athleteId);
+        REFRESHING.delete(key);
     }
 }
 
 export async function POST(request: Request) {
     try {
-        const body = await request.json() as { stravaCredentials?: StravaCredentials };
-        const { stravaCredentials } = body;
+        const body = await request.json() as { stravaCredentials?: StravaCredentials; activityMode?: string };
+        const { stravaCredentials, activityMode } = body;
         if (!stravaCredentials?.refreshToken) {
             return NextResponse.json({ error: 'stravaCredentials.refreshToken required to identify athlete' }, { status: 400 });
         }
+        const mode: ActivityMode = activityMode === 'running' ? 'running' : 'cycling';
 
         const athleteId = await resolveAthleteId(stravaCredentials);
-        const cached = await withDbRetry(() => prisma.statsCache.findUnique({ where: { athleteId } }), 'read cache');
+        const key = cacheKey(athleteId, mode);
+        const cached = await withDbRetry(() => prisma.statsCache.findUnique({ where: { athleteId: key } }), 'read cache');
 
         if (cached) {
             const ageMs = Date.now() - cached.refreshedAt.getTime();
@@ -335,14 +345,14 @@ export async function POST(request: Request) {
             const outdatedSchema = cachedVersion < STATS_VERSION;
 
             if (stale || outdatedSchema) {
-                refreshInBackground(athleteId, stravaCredentials);
+                refreshInBackground(athleteId, stravaCredentials, mode);
             }
             const payload = cached.stats as unknown as StatsPayload;
             const response: StatsResponse = {
                 ...payload,
                 refreshedAt: cached.refreshedAt.toISOString(),
                 stale,
-                refreshing: REFRESHING.has(athleteId),
+                refreshing: REFRESHING.has(key),
                 computing: false
             };
             return NextResponse.json(response);
@@ -351,8 +361,8 @@ export async function POST(request: Request) {
         // No cache — kick off the computation in the background and return
         // immediately. The client polls /api/stats until cached data appears
         // so the dialog never blocks on a multi-minute cold compute.
-        console.log(`${ts()} Stats: cold compute kicked off for athlete ${athleteId}`);
-        refreshInBackground(athleteId, stravaCredentials);
+        console.log(`${ts()} Stats: cold compute kicked off for ${key}`);
+        refreshInBackground(athleteId, stravaCredentials, mode);
         const response: StatsResponse = {
             refreshedAt: null,
             stale: false,

--- a/app/api/strava/activities/route.test.ts
+++ b/app/api/strava/activities/route.test.ts
@@ -56,4 +56,24 @@ describe('POST /api/strava/activities', () => {
         expect(data.error).toBe('Token expired');
         expect(Object.keys(data)).toEqual(['error']);
     });
+
+    it('defaults to cycling mode when activityMode is omitted', async () => {
+        mockedFetch.mockResolvedValueOnce({
+            riddenRoads: [], activityElevations: [], activityTypes: [],
+            activityDistances: [], activityStartDates: [],
+            totalCyclingActivities: 0, totalCyclingElevationGainMeters: 0,
+        });
+        await POST(makeRequest({}));
+        expect(mockedFetch).toHaveBeenCalledWith(undefined, 'cycling');
+    });
+
+    it('passes activityMode: "running" through to fetchCyclingRiddenRoads', async () => {
+        mockedFetch.mockResolvedValueOnce({
+            riddenRoads: [], activityElevations: [], activityTypes: [],
+            activityDistances: [], activityStartDates: [],
+            totalCyclingActivities: 0, totalCyclingElevationGainMeters: 0,
+        });
+        await POST(makeRequest({ activityMode: 'running' }));
+        expect(mockedFetch).toHaveBeenCalledWith(undefined, 'running');
+    });
 });

--- a/app/api/strava/activities/route.ts
+++ b/app/api/strava/activities/route.ts
@@ -4,7 +4,8 @@ import { fetchCyclingRiddenRoads, forceSyncStravaActivities } from '@/lib/strava
 export async function POST(req: Request) {
     try {
         const body = await req.json();
-        const { stravaCredentials, forceSync } = body;
+        const { stravaCredentials, forceSync, activityMode } = body;
+        const mode: 'cycling' | 'running' = activityMode === 'running' ? 'running' : 'cycling';
 
         if (stravaCredentials) {
             console.log(`[API/Strava] Received credentials in request. Keys: ${Object.keys(stravaCredentials).join(', ')}`);
@@ -19,7 +20,7 @@ export async function POST(req: Request) {
         }
 
         if (forceSync) await forceSyncStravaActivities(stravaCredentials);
-        const { riddenRoads, activityElevations, activityTypes } = await fetchCyclingRiddenRoads(stravaCredentials);
+        const { riddenRoads, activityElevations, activityTypes } = await fetchCyclingRiddenRoads(stravaCredentials, mode);
 
         return NextResponse.json({ riddenRoads, activityElevations, activityTypes });
     } catch (error: any) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { ErrorDialog } from '@/components/ErrorDialog';
 import dynamic from 'next/dynamic';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Loader2, Undo2, Redo2, Settings2, Check, ChevronDown, Eraser, Settings, BarChart3, Home as HomeIcon, X, Menu, MoreVertical } from 'lucide-react';
+import { Loader2, Undo2, Redo2, Settings2, Check, ChevronDown, Eraser, Settings, BarChart3, Home as HomeIcon, X, Menu, MoreVertical, Bike, Footprints } from 'lucide-react';
 import { StravaSettingsDialog } from '@/components/StravaSettingsDialog';
 import { StravaHeaderButton } from '@/components/StravaHeaderButton';
 import { StatsDialog } from '@/components/StatsDialog';
@@ -130,6 +130,30 @@ export default function Home() {
     }, []);
     const [isEraserMode, setIsEraserMode] = useState(false);
     const [isAvoidMode, setIsAvoidMode] = useState(false);
+
+    // Cycling vs running (#88): filters which Strava activity types count as
+    // "ridden" everywhere (map overlay, coverage stats, routing penalty).
+    // Prompted once on first run, then persisted; changeable later from
+    // Routing Preferences.
+    const ACTIVITY_MODE_KEY = 'activity_mode';
+    const [activityMode, setActivityMode] = useState<'cycling' | 'running'>('cycling');
+    const [showActivityModePrompt, setShowActivityModePrompt] = useState(false);
+    useEffect(() => {
+        try {
+            const saved = localStorage.getItem(ACTIVITY_MODE_KEY);
+            if (saved === 'cycling' || saved === 'running') {
+                setActivityMode(saved);
+            } else {
+                setShowActivityModePrompt(true);
+            }
+        } catch { /* ignore */ }
+    }, []);
+    const chooseActivityMode = useCallback((mode: 'cycling' | 'running') => {
+        setActivityMode(mode);
+        setShowActivityModePrompt(false);
+        try { localStorage.setItem(ACTIVITY_MODE_KEY, mode); } catch { /* ignore */ }
+    }, []);
+
     const [showStravaSettings, setShowStravaSettings] = useState(false);
     const [stravaCredentials, setStravaCredentials] = useState<any>(undefined);
     const [stravaError, setStravaError] = useState<string | null>(null);
@@ -325,7 +349,7 @@ export default function Home() {
             return;
         }
 
-        const credentialsKey = JSON.stringify(stravaCredentials);
+        const credentialsKey = JSON.stringify({ ...stravaCredentials, activityMode });
 
         setStravaError(null);
         setIsStravaLoading(true);
@@ -344,7 +368,7 @@ export default function Home() {
             fetch('/api/strava/activities', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ stravaCredentials, forceSync: skipCache })
+                body: JSON.stringify({ stravaCredentials, forceSync: skipCache, activityMode })
             })
                 .then(res => res.json())
                 .then(data => {
@@ -373,7 +397,7 @@ export default function Home() {
                     setIsStravaLoading(false);
                 });
         });
-    }, [stravaCredentials, stravaRefreshKey]);
+    }, [stravaCredentials, stravaRefreshKey, activityMode]);
 
     // Fetch the server-precomputed, deduped ridden-road overlay. It's
     // viewport-independent, so the map draws it instantly with no per-pan wait.
@@ -385,7 +409,7 @@ export default function Home() {
         if (!stravaCredentials?.refreshToken) { setPrecomputedRidden(null); setIsRiddenComputing(false); return; }
         let cancelled = false;
         let timer: ReturnType<typeof setTimeout> | null = null;
-        const credentialsKey = JSON.stringify(stravaCredentials);
+        const credentialsKey = JSON.stringify({ ...stravaCredentials, activityMode });
         const skipCache = stravaRefreshKey > 0;
 
         const fetchFresh = async () => {
@@ -393,7 +417,7 @@ export default function Home() {
                 const res = await fetch('/api/ridden-roads', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ stravaCredentials })
+                    body: JSON.stringify({ stravaCredentials, activityMode })
                 });
                 const data = await res.json();
                 if (cancelled || data.error) { setIsRiddenComputing(false); return; }
@@ -422,7 +446,7 @@ export default function Home() {
             });
         }
         return () => { cancelled = true; if (timer) clearTimeout(timer); };
-    }, [stravaCredentials, stravaRefreshKey]);
+    }, [stravaCredentials, stravaRefreshKey, activityMode]);
 
     const handleBBoxChange = useCallback((newBbox: { south: number; west: number; north: number; east: number }) => {
         setBbox(prev => {
@@ -1659,6 +1683,26 @@ export default function Home() {
                                             </div>
                                             <div className="w-full px-3 py-3 border-t border-gray-200">
                                                 <label className="text-sm font-medium text-gray-700 mb-2 block">
+                                                    Activity Type
+                                                </label>
+                                                <div className="flex items-center rounded-md border border-gray-300 overflow-hidden text-sm font-medium bg-white">
+                                                    <button
+                                                        onClick={() => chooseActivityMode('cycling')}
+                                                        className={`flex-1 px-3 py-1.5 transition-colors ${activityMode === 'cycling' ? 'bg-indigo-600 text-white' : 'text-gray-700 hover:bg-gray-50'}`}
+                                                    >
+                                                        Cycling
+                                                    </button>
+                                                    <button
+                                                        onClick={() => chooseActivityMode('running')}
+                                                        className={`flex-1 px-3 py-1.5 transition-colors border-l border-gray-300 ${activityMode === 'running' ? 'bg-indigo-600 text-white' : 'text-gray-700 hover:bg-gray-50'}`}
+                                                    >
+                                                        Running
+                                                    </button>
+                                                </div>
+                                                <p className="text-xs text-gray-500 mt-2">Filters which Strava activities count as ridden roads and coverage</p>
+                                            </div>
+                                            <div className="w-full px-3 py-3 border-t border-gray-200">
+                                                <label className="text-sm font-medium text-gray-700 mb-2 block">
                                                     Point Route Detour Preference: {routingOptions.pointRoutePenalty}x
                                                 </label>
                                                 <input
@@ -2308,6 +2352,7 @@ export default function Home() {
                     activityElevations={stravaElevations}
                     activityTypes={stravaTypes}
                     stravaCredentials={stravaCredentials}
+                    activityMode={activityMode}
                 />
 
                 {error && (
@@ -2319,6 +2364,31 @@ export default function Home() {
                 )}
 
                 <HowToDialog isOpen={showHowTo} onClose={closeHowTo} />
+
+                {showActivityModePrompt && (
+                    <div className="fixed inset-0 z-[2100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+                        <div className="bg-white rounded-xl shadow-2xl w-full max-w-sm p-6 text-center">
+                            <h2 className="text-lg font-bold text-gray-900 mb-2">What are you using StreetSweep for?</h2>
+                            <p className="text-sm text-gray-500 mb-5">This decides which Strava activities count as roads you&apos;ve covered. You can change it later in Routing Preferences.</p>
+                            <div className="flex gap-3">
+                                <button
+                                    onClick={() => chooseActivityMode('cycling')}
+                                    className="flex-1 flex flex-col items-center gap-1.5 px-4 py-3 rounded-lg border border-gray-300 text-sm font-semibold text-gray-800 hover:bg-indigo-50 hover:border-indigo-300"
+                                >
+                                    <Bike className="w-5 h-5" />
+                                    Cycling
+                                </button>
+                                <button
+                                    onClick={() => chooseActivityMode('running')}
+                                    className="flex-1 flex flex-col items-center gap-1.5 px-4 py-3 rounded-lg border border-gray-300 text-sm font-semibold text-gray-800 hover:bg-indigo-50 hover:border-indigo-300"
+                                >
+                                    <Footprints className="w-5 h-5" />
+                                    Running
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
                 <button
                     onClick={() => setShowHowTo(true)}
                     title="How to use StreetSweep"

--- a/components/StatsDialog.tsx
+++ b/components/StatsDialog.tsx
@@ -38,6 +38,7 @@ interface StatsDialogProps {
     activityElevations: number[];
     activityTypes: string[];
     stravaCredentials: any;
+    activityMode: 'cycling' | 'running';
 }
 
 interface StateItem { name: string; country: string }
@@ -105,7 +106,7 @@ function formatAge(refreshedAt?: string): string | null {
     return `${days}d ago`;
 }
 
-export function StatsDialog({ isOpen, onClose, riddenRoads, activityElevations, activityTypes, stravaCredentials }: StatsDialogProps) {
+export function StatsDialog({ isOpen, onClose, riddenRoads, activityElevations, activityTypes, stravaCredentials, activityMode }: StatsDialogProps) {
     const [stats, setStats] = useState<StatsResponse | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -132,7 +133,7 @@ export function StatsDialog({ isOpen, onClose, riddenRoads, activityElevations, 
                 const res = await fetch('/api/stats', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ stravaCredentials })
+                    body: JSON.stringify({ stravaCredentials, activityMode })
                 });
                 const data = await res.json();
                 if (cancelled) return;
@@ -160,7 +161,7 @@ export function StatsDialog({ isOpen, onClose, riddenRoads, activityElevations, 
             cancelled = true;
             if (pollTimer) clearTimeout(pollTimer);
         };
-    }, [isOpen, riddenRoads, stravaCredentials]);
+    }, [isOpen, riddenRoads, stravaCredentials, activityMode]);
 
     const [ftpReadings, setFtpReadings] = useState<FtpReading[] | null>(null);
     const [showFtpDetail, setShowFtpDetail] = useState(false);

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -1,4 +1,4 @@
-import { buildCoverageCells, cellsToMiles, computeUniqueMiles, pointInPolygon, isBikingActivity, isCyclingActivity, computeRideRecords } from './stats';
+import { buildCoverageCells, cellsToMiles, computeUniqueMiles, pointInPolygon, isBikingActivity, isCyclingActivity, isRunningActivity, isRunningActivityBroad, isModeActivity, isModeActivityBroad, computeRideRecords } from './stats';
 
 describe('stats.buildCoverageCells', () => {
     it('returns no cells for empty input', () => {
@@ -107,6 +107,56 @@ describe('stats.isCyclingActivity', () => {
     it('rejects undefined / empty', () => {
         expect(isCyclingActivity(undefined)).toBe(false);
         expect(isCyclingActivity('')).toBe(false);
+    });
+});
+
+describe('stats.isRunningActivity', () => {
+    it('accepts known run sport types (case-insensitive)', () => {
+        expect(isRunningActivity('Run')).toBe(true);
+        expect(isRunningActivity('run')).toBe(true);
+        expect(isRunningActivity('TrailRun')).toBe(true);
+    });
+
+    it('rejects non-running activity types, including cycling', () => {
+        expect(isRunningActivity('Ride')).toBe(false);
+        expect(isRunningActivity('Walk')).toBe(false);
+        expect(isRunningActivity('Hike')).toBe(false);
+    });
+
+    it('rejects virtual/treadmill runs (no real-world GPS)', () => {
+        expect(isRunningActivity('VirtualRun')).toBe(false);
+    });
+
+    it('rejects undefined / empty', () => {
+        expect(isRunningActivity(undefined)).toBe(false);
+        expect(isRunningActivity('')).toBe(false);
+    });
+});
+
+describe('stats.isRunningActivityBroad', () => {
+    it('also accepts VirtualRun unlike isRunningActivity', () => {
+        expect(isRunningActivityBroad('VirtualRun')).toBe(true);
+        expect(isRunningActivityBroad('Run')).toBe(true);
+        expect(isRunningActivity('VirtualRun')).toBe(false);
+    });
+});
+
+describe('stats.isModeActivity / isModeActivityBroad', () => {
+    it('cycling mode matches only bike types', () => {
+        expect(isModeActivity('Ride', 'cycling')).toBe(true);
+        expect(isModeActivity('Run', 'cycling')).toBe(false);
+    });
+
+    it('running mode matches only run types', () => {
+        expect(isModeActivity('Run', 'running')).toBe(true);
+        expect(isModeActivity('Ride', 'running')).toBe(false);
+    });
+
+    it('broad variants include the virtual counterpart for each mode', () => {
+        expect(isModeActivityBroad('VirtualRide', 'cycling')).toBe(true);
+        expect(isModeActivityBroad('VirtualRun', 'running')).toBe(true);
+        expect(isModeActivityBroad('VirtualRun', 'cycling')).toBe(false);
+        expect(isModeActivityBroad('VirtualRide', 'running')).toBe(false);
     });
 });
 

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -150,3 +150,34 @@ export function isCyclingActivity(type?: string): boolean {
     if (!type) return false;
     return isBikingActivity(type) || type.toLowerCase() === 'virtualride';
 }
+
+// Outdoor running types only, mirroring BIKING_TYPES above. 'virtualrun'
+// (treadmill) is deliberately excluded for the same reason 'virtualride' is:
+// no real-world GPS location.
+const RUNNING_TYPES = new Set([
+    'run',
+    'trailrun',
+]);
+
+export function isRunningActivity(type?: string): boolean {
+    if (!type) return false;
+    return RUNNING_TYPES.has(type.toLowerCase());
+}
+
+// Mirrors isCyclingActivity's broader "counts toward lifetime totals" check.
+export function isRunningActivityBroad(type?: string): boolean {
+    if (!type) return false;
+    return isRunningActivity(type) || type.toLowerCase() === 'virtualrun';
+}
+
+export type ActivityMode = 'cycling' | 'running';
+
+// Real-world-GPS check (map overlay / ridden roads) for the given mode.
+export function isModeActivity(type: string | undefined, mode: ActivityMode): boolean {
+    return mode === 'cycling' ? isBikingActivity(type) : isRunningActivity(type);
+}
+
+// Broader "counts toward lifetime totals" check for the given mode.
+export function isModeActivityBroad(type: string | undefined, mode: ActivityMode): boolean {
+    return mode === 'cycling' ? isCyclingActivity(type) : isRunningActivityBroad(type);
+}

--- a/lib/strava.test.ts
+++ b/lib/strava.test.ts
@@ -194,4 +194,50 @@ describe('fetchCyclingRiddenRoads', () => {
         expect(result.riddenRoads[0]).not.toEqual(summaryDecoded);
         expect(prisma.stravaActivityDetail.upsert).not.toHaveBeenCalled(); // already cached -- no backfill needed
     });
+
+    it('running mode keeps only Run/TrailRun activities and excludes rides', async () => {
+        const activities = [
+            mockActivity({ id: 1, type: 'Ride', total_elevation_gain: 100 }),
+            mockActivity({ id: 2, type: 'Run', total_elevation_gain: 50 }),
+            mockActivity({ id: 3, type: 'TrailRun', total_elevation_gain: 75 }),
+        ];
+        (global.fetch as jest.Mock).mockImplementation((url: string) => {
+            if (url.includes('oauth/token')) return Promise.resolve({ ok: true, json: async () => ({ access_token: 'token', scope: 'activity:read' }) });
+            if (isDetailUrl(url)) return Promise.resolve({ ok: true, json: async () => ({ map: {} }) });
+            if (url.includes('/athlete') && !url.includes('activities')) return Promise.resolve({ ok: true, json: async () => ({ id: 999 }) });
+            if (url.includes('/activities')) {
+                const isPage1 = url.includes('page=1&');
+                return Promise.resolve({ ok: true, json: async () => (isPage1 ? activities : []) });
+            }
+            throw new Error('unexpected fetch: ' + url);
+        });
+
+        const result = await fetchCyclingRiddenRoads(creds, 'running');
+
+        expect(result.riddenRoads.length).toBe(2); // Run + TrailRun, Ride excluded
+        expect(result.totalCyclingActivities).toBe(2);
+        expect(result.totalCyclingElevationGainMeters).toBe(125); // 50 + 75
+    });
+
+    it('cycling mode (default) excludes running activities', async () => {
+        const activities = [
+            mockActivity({ id: 1, type: 'Ride', total_elevation_gain: 100 }),
+            mockActivity({ id: 2, type: 'Run', total_elevation_gain: 50 }),
+        ];
+        (global.fetch as jest.Mock).mockImplementation((url: string) => {
+            if (url.includes('oauth/token')) return Promise.resolve({ ok: true, json: async () => ({ access_token: 'token', scope: 'activity:read' }) });
+            if (isDetailUrl(url)) return Promise.resolve({ ok: true, json: async () => ({ map: {} }) });
+            if (url.includes('/athlete') && !url.includes('activities')) return Promise.resolve({ ok: true, json: async () => ({ id: 999 }) });
+            if (url.includes('/activities')) {
+                const isPage1 = url.includes('page=1&');
+                return Promise.resolve({ ok: true, json: async () => (isPage1 ? activities : []) });
+            }
+            throw new Error('unexpected fetch: ' + url);
+        });
+
+        const result = await fetchCyclingRiddenRoads(creds);
+
+        expect(result.riddenRoads.length).toBe(1);
+        expect(result.totalCyclingActivities).toBe(1);
+    });
 });

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -1,5 +1,5 @@
 import polyline from '@mapbox/polyline';
-import { isBikingActivity, isCyclingActivity } from './stats';
+import { isModeActivity, isModeActivityBroad, ActivityMode } from './stats';
 import { haversineM } from './geometry';
 import { prisma } from './prisma';
 import { parseFtpFromComment, parseFtpFromNamedActivityComment, FtpReading } from './ftp';
@@ -47,14 +47,15 @@ export interface RiddenActivities {
     totalCyclingElevationGainMeters: number;
 }
 
-// Single source of truth for what the app treats as "ridden": real-world cycling
-// only. Non-cycling activities (walks/hikes/runs) and rides whose track barely
-// moves (stationary/indoor trainers) are dropped here so they never reach the
-// map overlay, coverage stats, or the routing ridden-penalty.
-export async function fetchCyclingRiddenRoads(creds?: { clientId?: string; clientSecret?: string; refreshToken?: string }): Promise<RiddenActivities> {
+// Single source of truth for what the app treats as "ridden": real-world
+// activity of the selected mode (cycling or running) only. Everything else
+// (the other mode, walks/hikes) and tracks that barely move (stationary/
+// indoor trainers) are dropped here so they never reach the map overlay,
+// coverage stats, or the routing ridden-penalty.
+export async function fetchCyclingRiddenRoads(creds?: { clientId?: string; clientSecret?: string; refreshToken?: string }, mode: ActivityMode = 'cycling'): Promise<RiddenActivities> {
     const athleteId = await resolveAthleteId(creds);
     const all = await getCachedOrFetchActivities(creds);
-    const realCandidates = all.filter(a => isBikingActivity(a.sport_type || a.type));
+    const realCandidates = all.filter(a => isModeActivity(a.sport_type || a.type, mode));
 
     // Prefer the full-resolution polyline (StravaActivityDetail) when it's been
     // backfilled -- Strava's summary_polyline is decimated for map thumbnails
@@ -80,7 +81,7 @@ export async function fetchCyclingRiddenRoads(creds?: { clientId?: string; clien
         console.warn(`[Strava] Detail backfill skipped: ${e.message}`);
     }
 
-    const allCycling = all.filter(a => isCyclingActivity(a.sport_type || a.type));
+    const allCycling = all.filter(a => isModeActivityBroad(a.sport_type || a.type, mode));
     return {
         riddenRoads: real.map(r => r.poly),
         activityElevations: real.map(r => r.a.total_elevation_gain ?? 0),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "street-sweep",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "street-sweep",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "dependencies": {
         "@garmin/fitsdk": "^21.202.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "street-sweep",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3888",


### PR DESCRIPTION
## Summary
- First-run prompt asks whether the rider is using StreetSweep for cycling or running; persisted to localStorage and changeable later from Routing Preferences.
- Ridden-roads overlay, coverage stats, and the routing ridden-penalty now filter Strava activities by the selected mode instead of being hardcoded to cycling.
- Postgres-cached routes (ridden-roads, stats) key their cache per mode so switching modes never mixes cached data — no DB migration needed.

Closes #88

## Test plan
- [x] `npm test` (390 tests) passes
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] Manually verified locally: mode prompt on first load, toggle in Routing Preferences